### PR TITLE
Fix Android compile for non arm platforms

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -445,23 +445,20 @@ ifdef WITH_DYNAREC
 		endif
 	else ifeq ($(WITH_DYNAREC), arm64)
       DYNAFLAGS += -D_ARCH_64
-      SOURCES_CXX += $(COMMONDIR)/ArmEmitter.cpp \
-		     $(EXTDIR)/disarm.cpp \
+      SOURCES_CXX += $(COMMONDIR)/Arm64Emitter.cpp \
 		     $(COMMONDIR)/ArmCPUDetect.cpp \
-		     $(COMMONDIR)/ArmThunk.cpp \
-		     $(COMMONDIR)/Arm64Emitter.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmAsm.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmCompALU.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmCompBranch.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmCompFPU.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmCompLoadStore.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmCompVFPU.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmCompReplace.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmJit.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmRegCache.cpp \
-		     $(COREDIR)/MIPS/ARM/ArmRegCacheFPU.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64Asm.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64CompALU.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64CompBranch.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64CompFPU.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64CompLoadStore.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64CompVFPU.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64CompReplace.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64Jit.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64RegCache.cpp \
+		     $(COREDIR)/MIPS/ARM64/Arm64RegCacheFPU.cpp \
 		     $(COREDIR)/Util/DisArm64.cpp \
-		     $(GPUCOMMONDIR)/VertexDecoderArm.cpp
+		     $(GPUCOMMONDIR)/VertexDecoderArm64.cpp
 		
 		ifeq ($(HAVE_NEON),1)
 			SOURCES_CXX   += \

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -1,91 +1,85 @@
 LOCAL_PATH := $(call my-dir)
 
-include $(CLEAR_VARS)
-
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
-	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+	COREFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 
-LOCAL_MODULE    := libavformat
-CORE_DIR        := ../..
-FFMPEGDIR       := $(CORE_DIR)/ffmpeg
-FFMPEGLIBDIR    := $(FFMPEGDIR)/android/armv7/lib
-LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libavformat.a
+COREFLAGS  :=
+CORE_DIR   := ../..
+FFMPEGDIR  := $(CORE_DIR)/ffmpeg
+FFMPEGLIBS += libavformat libavcodec libavutil libswresample libswscale
 
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-
-LOCAL_MODULE    := libavcodec
-LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libavcodec.a
-
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-
-LOCAL_MODULE    := libavutil
-LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libavutil.a
-
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-
-LOCAL_MODULE    := libswresample
-LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libswresample.a
-
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-
-LOCAL_MODULE    := libswscale
-LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libswscale.a
-
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-
+ifeq ($(TARGET_ARCH),arm64)
+  COREFLAGS += -DARM64 -D_ARCH_64
+  HAVE_NEON := 1
+  WITH_DYNAREC = arm64
+  FFMPEGLIBDIR := $(FFMPEGDIR)/android/arm64/lib
+  FFMPEGINCFLAGS := -I$(FFMPEGDIR)/android/arm64/include
+endif
 
 ifeq ($(TARGET_ARCH),arm)
-  LOCAL_CFLAGS += -DANDROID_ARM -DARM -DARMEABI_V7A
-  LOCAL_ARM_MODE := arm
-ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
-  LOCAL_ARM_NEON := true
-endif
-  LOCAL_CLFAGS += -marm
+  COREFLAGS += -DARM -DARMEABI_V7A -D__arm__ -DARM_ASM -D_ARCH_32 -mfpu=neon
+  HAVE_NEON := 1
+  WITH_DYNAREC = arm
+  FFMPEGLIBDIR := $(FFMPEGDIR)/android/armv7/lib
+  FFMPEGINCFLAGS := -I$(FFMPEGDIR)/android/armv7/include
 endif
 
 ifeq ($(TARGET_ARCH),x86)
-  LOCAL_CFLAGS += -DANDROID_X86 -D_M_IX86 -fomit-frame-pointer -mtune=atom -mfpmath=sse -mssse3
+  COREFLAGS += -D_ARCH_32 -D_M_IX86 -fomit-frame-pointer -mtune=atom -mfpmath=sse -mssse3 -mstackrealign
+  WITH_DYNAREC = x86
+  FFMPEGLIBDIR := $(FFMPEGDIR)/android/x86/lib
+  FFMPEGINCFLAGS := -I$(FFMPEGDIR)/android/x86/include
 endif
 
-ifeq ($(TARGET_ARCH),mips)
-  LOCAL_CFLAGS += -DANDROID_MIPS
+ifeq ($(TARGET_ARCH),x86_64)
+  COREFLAGS += -D_ARCH_64 -D_M_X64 -fomit-frame-pointer -mtune=atom -mfpmath=sse -mssse3 -mstackrealign
+  WITH_DYNAREC = x86_64
+  FFMPEGLIBDIR := $(FFMPEGDIR)/android/x86_64/lib
+  FFMPEGINCFLAGS := -I$(FFMPEGDIR)/android/x86_64/include
 endif
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := libavformat
+LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libavformat.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := libavcodec
+LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libavcodec.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := libavutil
+LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libavutil.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := libswresample
+LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libswresample.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE    := libswscale
+LOCAL_SRC_FILES := $(FFMPEGLIBDIR)/libswscale.a
+include $(PREBUILT_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
 
 PLATFORM_EXT   := android
-
-FFMPEGINCFLAGS := -I$(FFMPEGDIR)/android/armv7/include
-FFMPEGLIBDIR   := $(FFMPEGDIR)/android/armv7/lib
-FFMPEGLIBS     += libavformat libavcodec libavutil libswresample libswscale
-
-WITH_DYNAREC = arm
+platform := android
 GLES = 1
-
-INCFLAGS += $(FFMPEGINCFLAGS)
 
 LOCAL_MODULE := retro
 
-platform := android
-HAVE_NEON := 1
-
 include $(CORE_DIR)/libretro/Makefile.common
 
-COREFLAGS := -DINLINE="inline" -DPPSSPP -DUSE_FFMPEG -DMOBILE_DEVICE -DBAKE_IN_GIT -DDYNAREC -D__LIBRETRO__ -D__arm__ -DARM_ASM -D__NEON_OPT__ -DUSING_GLES2 -D__STDC_CONSTANT_MACROS -D_ARCH_32 -DGLEW_NO_GLU -DNO_VULKAN $(INCFLAGS)
+COREFLAGS += -DINLINE="inline" -DPPSSPP -DUSE_FFMPEG -DMOBILE_DEVICE -DBAKE_IN_GIT -DDYNAREC -D__LIBRETRO__ -DUSING_GLES2 -D__STDC_CONSTANT_MACROS -DGLEW_NO_GLU -DNO_VULKAN $(INCFLAGS)
 LOCAL_SRC_FILES = $(SOURCES_CXX) $(SOURCES_C) $(ASMFILES)
 LOCAL_CPPFLAGS := -Wall -std=gnu++11 -Wno-literal-suffix $(COREFLAGS)
 LOCAL_CFLAGS := -O2 -ffast-math -DANDROID $(COREFLAGS)
-LOCAL_LDLIBS += -lz -llog -lGLESv2 -lEGL
+LOCAL_LDLIBS += -lz -llog -lGLESv2 -lEGL -latomic
 LOCAL_STATIC_LIBRARIES += $(FFMPEGLIBS)
 
 include $(BUILD_SHARED_LIBRARY)

--- a/libretro/jni/Application.mk
+++ b/libretro/jni/Application.mk
@@ -1,5 +1,5 @@
 NDK_TOOLCHAIN_VERSION ?= 4.8
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a,arm64-v8a,x86
 APP_STL := gnustl_static
 APP_GNUSTL_CPP_FEATURES :=
 APP_PLATFORM := android-9


### PR DESCRIPTION
This cleans up the armv7 android jni a bit. Older than armv7 won't compile anyways, so removed checks for it and assume neon is always available. Tested and works as well as before.
Fixed arm64 compile. Tested and works on par with armv7.
Fixed x86 compile. Do not have device to test.
Fixed x86_64 as much as possible, but prebuilt ffmpeg libs are not pic compliant. Afaik, all x86 android devices run in 32-bit mode, so this isn't really an issue.
Removed mips references from the jni. Not sure that would have ever worked.