### PR TITLE
More upstream friendly savestate method

### DIFF
--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -48,6 +48,11 @@
 
 namespace SaveState
 {
+	struct SaveStart
+	{
+		void DoState(PointerWrap &p);
+	};
+
 	enum OperationType
 	{
 		SAVESTATE_SAVE,

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -23,11 +23,6 @@
 
 namespace SaveState
 {
-	struct SaveStart
-	{
-		void DoState(PointerWrap &p);
-	};
-
 	typedef std::function<void(bool status, const std::string &message, void *cbUserData)> Callback;
 
 	static const int NUM_SLOTS = 5;


### PR DESCRIPTION
Tested on linux x86_64 and android aarch64. This uses the already existing public functions upstream provides. Stores the size of the vector in the first 4 bytes of the state.