### PR TITLE
Add .gitignore for libretro.

### DIFF
--- a/libretro/.gitignore
+++ b/libretro/.gitignore
@@ -1,0 +1,4 @@
+*.bc
+*.so
+*.dll
+*.dylib


### PR DESCRIPTION
My proposal is to add ignore `.o` files in the upstream `.gitignore` file and the library core files in the `libretro` directory.

So please do not merge yet. Wait for these two things.

1. For upstream ppsspp to make a decision on this PR. https://github.com/hrydgard/ppsspp/pull/10143
2. For the buildbot to conclude so that we can see the status after the last PR.