### PR TITLE
Reset glew.c to upstream.

### DIFF
--- a/ext/glew/glew.c
+++ b/ext/glew/glew.c
@@ -32,33 +32,18 @@
 
 #include "GL/glew.h"
 
-#ifdef __LIBRETRO__
-#undef GLEW_REGAL
-#undef GLEW_APPLE_GLX
-#include <libretro.h>
-extern retro_hw_get_proc_address_t libretro_get_proc_address;
-#else
 #if defined(_WIN32)
 #  include <GL/wglew.h>
 #elif !defined(__ANDROID__) && !defined(__native_client__) && !defined(__HAIKU__) && (!defined(__APPLE__) || defined(GLEW_APPLE_GLX))
 #  include "GL/glxew.h"
 #endif
-#endif
 
 #include <stddef.h>  /* For size_t */
 
-#ifdef __LIBRETRO__
-#  define GLEW_CONTEXT_ARG_DEF_INIT void
-#  define GLEW_CONTEXT_ARG_VAR_INIT
-#  define GLEW_CONTEXT_ARG_DEF_LIST void
-#  define WGLEW_CONTEXT_ARG_DEF_INIT void
-#  define WGLEW_CONTEXT_ARG_DEF_LIST void
-#  define GLXEW_CONTEXT_ARG_DEF_INIT void
-#  define GLXEW_CONTEXT_ARG_DEF_LIST void
 /*
  * Define glewGetContext and related helper macros.
  */
-#elif defined(GLEW_MX)
+#ifdef GLEW_MX
 #  define glewGetContext() ctx
 #  ifdef _WIN32
 #    define GLEW_CONTEXT_ARG_DEF_INIT GLEWContext* ctx
@@ -84,13 +69,11 @@ extern retro_hw_get_proc_address_t libretro_get_proc_address;
 #  define GLXEW_CONTEXT_ARG_DEF_LIST void
 #endif /* GLEW_MX */
 
-#if defined(__LIBRETRO__)
-#elif defined(GLEW_REGAL)
+#if defined(GLEW_REGAL)
 
 /* In GLEW_REGAL mode we call direcly into the linked
    libRegal.so glGetProcAddressREGAL for looking up
    the GL function pointers. */
-
 
 #  undef glGetProcAddressREGAL
 #  ifdef WIN32
@@ -124,7 +107,6 @@ void* dlGetProcAddress (const GLubyte* name)
     return dlsym(h, (const char*)name);
 }
 #endif /* __sgi || __sun || GLEW_APPLE_GLX */
-
 
 #if defined(__APPLE__)
 #include <stdlib.h>
@@ -185,8 +167,6 @@ void* NSGLGetProcAddress (const GLubyte *name)
 /*
  * Define glewGetProcAddress.
  */
-#if defined(__LIBRETRO__)
-#  define glewGetProcAddress(name) (libretro_get_proc_address)(name)
 #if defined(GLEW_REGAL)
 #  define glewGetProcAddress(name) regalGetProcAddress((const GLchar *) name)
 #elif defined(_WIN32)


### PR DESCRIPTION
Please wait on the buildbot before merging, I want to see if this somehow fixes it even though it should not be using this file....

Even if the libretro core should not use this file, resetting it to the current ppsspp master allows it to correctly build locally when either forcing cmake or the Makefile to use `glew.c`. Thus I don't think there is any reason to keep the broken diff? Please correct me if this is wrong.