### PR TITLE
Fix cmake compile with glew already installed on the system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,10 +119,6 @@ if(LIBRETRO)
 	add_definitions(-fPIC)
 
 	include_directories(libretro)
-
-	set(GLEW_LIBRARY glew_libretro.c)
-else()
-	set(GLEW_LIBRARY glew.c)
 endif()
 
 if(ANDROID)

--- a/ext/glew/CMakeLists.txt
+++ b/ext/glew/CMakeLists.txt
@@ -4,6 +4,11 @@ if(GLEW_FOUND)
   add_library(Ext::GLEW ALIAS system_glew)
   target_link_libraries(system_glew INTERFACE GLEW::GLEW)
 else()
+  if(LIBRETRO)
+    set(GLEW_LIBRARY glew_libretro.c)
+  else()
+    set(GLEW_LIBRARY glew.c)
+  endif()
   find_package(OpenGL REQUIRED)
   add_library(glew STATIC
     GL/glew.h


### PR DESCRIPTION
This was my mistake. If glew is already installed on a system this wont work and should only be set if a static glew is being used.