### PR TITLE
travis: Enable libretro builds for linux.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -106,6 +106,8 @@ travis_script() {
 
         if [ "$QT" = "TRUE" ]; then
             ./b.sh --qt
+        elif [ "$LIBRETRO" = "TRUE" ]; then
+            ./b.sh --libretro
         else
             ./b.sh --headless
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,14 @@ matrix:
       compiler: "gcc"
       env: PPSSPP_BUILD_TYPE=Linux
            QT=TRUE
+    - os: linux
+      compiler: "gcc"
+      env: PPSSPP_BUILD_TYPE=Linux
+           LIBRETRO=TRUE
+    - os: linux
+      compiler: "clang"
+      env: PPSSPP_BUILD_TYPE=Linux
+           LIBRETRO=TRUE
     - os: osx
       osx_image: xcode8
       compiler: "clang macos"

--- a/b.sh
+++ b/b.sh
@@ -33,6 +33,9 @@ do
 		--headless) echo "Headless mode enabled"
 			CMAKE_ARGS="-DHEADLESS=ON ${CMAKE_ARGS}"
 			;;
+		--libretro) echo "Libretro mode enabled"
+			CMAKE_ARGS="-DLIBRETRO=ON ${CMAKE_ARGS}"
+			;;
 		--unittest) echo "Build unittest"
 			CMAKE_ARGS="-DUNITTEST=ON ${CMAKE_ARGS}"
 			;;


### PR DESCRIPTION
This attempts to add travis libretro builds for Linux. It doesn't make sense to only test the upstream builds.

Note that I need the buildbot to test this as I can not do so locally.