### PR TITLE
cmake: Use glew_libretro.c even when glew is installed.

### DIFF
--- a/ext/glew/CMakeLists.txt
+++ b/ext/glew/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(GLEW)
+if(NOT LIBRETRO)
+  find_package(GLEW)
+endif()
 if(GLEW_FOUND)
   add_library(system_glew INTERFACE)
   add_library(Ext::GLEW ALIAS system_glew)


### PR DESCRIPTION
Given the explanation in https://github.com/libretro/ppsspp/pull/25 I thought it would be a good idea to force using `glew_libretro.c` with the cmake build like it is done with the Makefile.