### PR TITLE
libretro: Fix linux builds.

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -147,10 +147,14 @@ extern "C"
 retro_hw_get_proc_address_t libretro_get_proc_address;
 }
 
+// bandaid to fix non-android linux builds
+// vulkan should be implemented correctly
+#ifdef __ANDROID__
 bool VulkanMayBeAvailable() 
 {
    return false;
 }
+#endif
 
 class LibretroHost : public Host {
 public:


### PR DESCRIPTION
Not a proper solution, but this gets it building for linux again and works for the short term.

The proper solution would be to implement vulkan correctly for linux, windows and android. As I have no vulkan capable devices I can not even test this...