### PR TITLE
Remove hard coded variables CC and CXX for ARM platform

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -206,8 +206,6 @@ else ifeq ($(platform), qnx)
 
 # ARM
 else ifneq (,$(findstring armv,$(platform)))
-	CC = gcc
-	CXX = g++
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
 	LDFLAGS += -shared -Wl,--version-script=link.T -Wl,--no-undefined


### PR DESCRIPTION
It should fix issue #31 by using [correct compiler](https://github.com/libretro/libretro-super/blob/master/recipes/linux/cores-linux-armhf-generic.conf#L8-L9) for the buildbot.